### PR TITLE
Update CustomResourceDefinition to apiextensions.k8s.io/v1

### DIFF
--- a/config/300-postgressource.yaml
+++ b/config/300-postgressource.yaml
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   labels:


### PR DESCRIPTION
Currently there is an error when trying to appy.

```
error: resource mapping not found for name: "postgressources.sources.vaikas.dev" namespace: "" from "https://raw.githubusercontent.com/vaikas/postgressource/main/config/300-postgressource.yaml": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1”
```

https://kubernetes.io/blog/2021/07/14/upcoming-changes-in-kubernetes-1-22/

